### PR TITLE
HAS_NO_SYMBOL_RESOLVER switch support.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -127,19 +127,7 @@ option in 32bit, so 32bit is not tested. In addition, please check if there is
 run directly. If no, please apply the following change then built:
 
 ```
-diff --git a/src/Makefile b/src/Makefile
-index 7bbfe26..9ee06d7 100644
---- a/src/Makefile
-+++ b/src/Makefile
-@@ -3,7 +3,7 @@ obj-m += hookFrame.o
- hookFrame-y += framework/module.o
- hookFrame-y += framework/hijack_operation.o
- hookFrame-y += framework/stack_safety_check.o
--hookFrame-y += framework/symbol_resolver.o
-+hookFrame-y += framework/symbol_resolver_bak.o
- hookFrame-y += framework/write_map_page.o
- hookFrame-y += framework/proc_interface.o
- hookFrame-y += arch/$(ARCH)/hijack_$(ARCH).o
+make arm64 KDIR=??? HAS_NO_SYMBOL_RESOLVER=1
 ```
 
 Currently it support arm32, arm64, x86 and x86_64.

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,13 @@ obj-m += hookFrame.o
 hookFrame-y += framework/module.o
 hookFrame-y += framework/hijack_operation.o
 hookFrame-y += framework/stack_safety_check.o
+
+ifeq ($(HAS_NO_SYMBOL_RESOLVER),1)
+hookFrame-y += framework/symbol_resolver_bak.o
+else
 hookFrame-y += framework/symbol_resolver.o
+endif
+
 hookFrame-y += framework/write_map_page.o
 hookFrame-y += framework/proc_interface.o
 hookFrame-y += arch/$(ARCH)/hijack_$(ARCH).o


### PR DESCRIPTION
Add A make options to support HAS_NO_SYMBOL_RESOLVER , it can help make framework as a others porject's sub-module by Auto-Build Script.
```
#Check cat /proc/kallsyms | grep simplify_symbols is empty
if [ -z "$(cat /proc/kallsyms | grep simplify_symbols)" ]; then
  make arm64 KDIR=/lib/modules/$KERNEL_VERSION/build HAS_NO_SYMBOL_RESOLVER=1
else
  make arm64 KDIR=/lib/modules/$KERNEL_VERSION/build
fi
```